### PR TITLE
[refactor] Hoist common devDependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,35 +1,50 @@
 {
-  "extends": ["airbnb", "plugin:@typescript-eslint/recommended", "react-app"],
-  "parser": "@typescript-eslint/parser",
-  "plugins": ["@typescript-eslint"],
   "env": {
     "browser": true,
     "node": true
   },
+  "extends": ["airbnb", "plugin:@typescript-eslint/recommended", "react-app"],
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
   "rules": {
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/indent": ["error", 2],
+    "@typescript-eslint/no-angle-bracket-type-assertion": "off",
+    "@typescript-eslint/no-object-literal-type-assertion": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "args": "after-used",
+        "ignoreRestSiblings": true,
+        "vars": "all"
+      }
+    ],
+    "@typescript-eslint/prefer-interface": "off",
+    "import/extensions": "off",
+    "indent": "off",
     "no-underscore-dangle": "off",
     "object-curly-newline": [
       "error",
       {
-        "ObjectExpression": {
+        "ExportDeclaration": {
+          "consistent": true,
           "minProperties": 10,
-          "multiline": true,
-          "consistent": true
-        },
-        "ObjectPattern": {
-          "minProperties": 10,
-          "multiline": true,
-          "consistent": true
+          "multiline": true
         },
         "ImportDeclaration": {
+          "consistent": true,
           "minProperties": 10,
-          "multiline": true,
-          "consistent": true
+          "multiline": true
         },
-        "ExportDeclaration": {
+        "ObjectExpression": {
+          "consistent": true,
           "minProperties": 10,
-          "multiline": true,
-          "consistent": true
+          "multiline": true
+        },
+        "ObjectPattern": {
+          "consistent": true,
+          "minProperties": 10,
+          "multiline": true
         }
       }
     ],
@@ -38,26 +53,12 @@
       {
         "extensions": [".jsx", ".tsx"]
       }
-    ],
-    "import/extensions": "off",
-    "indent": "off",
-    "@typescript-eslint/indent": ["error", 2],
-    "@typescript-eslint/prefer-interface": "off",
-    "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/no-object-literal-type-assertion": "off",
-    "@typescript-eslint/no-unused-vars": [
-      "error",
-      {
-        "vars": "all",
-        "args": "after-used",
-        "ignoreRestSiblings": true
-      }
     ]
   },
   "settings": {
     "import/resolver": {
       "node": {
-        "extensions": [".mjs", ".js", ".json", ".ts", ".tsx"]
+        "extensions": [".js", ".json", ".mjs", ".ts", ".tsx"]
       }
     }
   }

--- a/.github/workflows/cd-workflow-blog.yml
+++ b/.github/workflows/cd-workflow-blog.yml
@@ -7,8 +7,9 @@ on:
       - master
     paths:
       - .github/workflows/cd-workflow-blog.yml
-      - configuration/*
-      - tooling/*
+      - package.json
+      - configuration/**
+      - tooling/**
       - sam-highlighter/**
       - blog/**
 

--- a/.github/workflows/cd-workflow-main-site-frontend.yml
+++ b/.github/workflows/cd-workflow-main-site-frontend.yml
@@ -7,8 +7,9 @@ on:
       - master
     paths:
       - .github/workflows/cd-workflow-main-site-frontend.yml
-      - configuration/*
-      - tooling/*
+      - package.json
+      - configuration/**
+      - tooling/**
       - sam-highlighter/**
       - main-site-frontend/**
 

--- a/.github/workflows/cd-workflow-samlang-demo-frontend.yml
+++ b/.github/workflows/cd-workflow-samlang-demo-frontend.yml
@@ -7,8 +7,9 @@ on:
       - master
     paths:
       - .github/workflows/cd-workflow-samlang-demo-frontend.yml
-      - configuration/*
-      - tooling/*
+      - package.json
+      - configuration/**
+      - tooling/**
       - sam-highlighter/**
       - samlang-demo-frontend/**
 

--- a/.github/workflows/cd-workflow-ten-web-frontend.yml
+++ b/.github/workflows/cd-workflow-ten-web-frontend.yml
@@ -7,8 +7,9 @@ on:
       - master
     paths:
       - .github/workflows/cd-workflow-ten-web-frontend.yml
-      - configuration/*
-      - tooling/*
+      - package.json
+      - configuration/**
+      - tooling/**
       - ten-web-frontend/**
 
 jobs:

--- a/.github/workflows/ci-workflow-blog.yml
+++ b/.github/workflows/ci-workflow-blog.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/ci-workflow-blog.yml
+      - package.json
       - configuration/**
       - tooling/**
       - sam-highlighter/**

--- a/.github/workflows/ci-workflow-main-site-frontend.yml
+++ b/.github/workflows/ci-workflow-main-site-frontend.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/ci-workflow-main-site-frontend.yml
+      - package.json
       - configuration/**
       - tooling/**
       - sam-highlighter/**

--- a/.github/workflows/ci-workflow-sam-highlighter.yml
+++ b/.github/workflows/ci-workflow-sam-highlighter.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/ci-workflow-sam-highlighter.yml
+      - package.json
       - configuration/**
       - tooling/**
       - sam-highlighter/**

--- a/.github/workflows/ci-workflow-samlang-demo-frontend.yml
+++ b/.github/workflows/ci-workflow-samlang-demo-frontend.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/ci-workflow-samlang-demo-frontend.yml
+      - package.json
       - configuration/**
       - tooling/**
       - sam-highlighter/**

--- a/.github/workflows/ci-workflow-ten-web-frontend.yml
+++ b/.github/workflows/ci-workflow-ten-web-frontend.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/ci-workflow-ten-web-frontend.yml
+      - package.json
       - configuration/**
       - tooling/**
       - ten-web-frontend/**

--- a/package.json
+++ b/package.json
@@ -13,5 +13,21 @@
     "samlang-demo-frontend",
     "ten-web-frontend",
     "tooling"
-  ]
+  ],
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^2.0.0",
+    "@typescript-eslint/parser": "^2.0.0",
+    "eslint": "^6.1.0",
+    "eslint-config-airbnb": "^18.0.1",
+    "eslint-config-react-app": "^5.0.1",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-react": "^7.14.3",
+    "eslint-plugin-react-hooks": "^1.7.0",
+    "firebase-tools": "7.2.2",
+    "react-app-rewired": "^2.1.3",
+    "react-scripts": "3.1.1",
+    "react-snap": "^1.23.0",
+    "typescript": "^3.5.3"
+  }
 }

--- a/tooling/package.json
+++ b/tooling/package.json
@@ -20,20 +20,5 @@
   },
   "dependencies": {
     "yargs": "^14.0.0"
-  },
-  "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.0.0",
-    "@typescript-eslint/parser": "^2.0.0",
-    "eslint": "^6.1.0",
-    "eslint-config-airbnb": "^18.0.1",
-    "eslint-plugin-import": "^2.18.2",
-    "eslint-plugin-jsx-a11y": "^6.2.3",
-    "eslint-plugin-react": "^7.14.3",
-    "eslint-plugin-react-hooks": "^1.7.0",
-    "firebase-tools": "7.2.2",
-    "react-app-rewired": "^2.1.3",
-    "react-scripts": "3.1.1",
-    "react-snap": "^1.23.0",
-    "typescript": "^3.5.3"
   }
 }

--- a/tooling/src/generator.ts
+++ b/tooling/src/generator.ts
@@ -2,21 +2,20 @@ import { getDependencyChain } from './workspace';
 
 const indentedLine = (text: string, space: number): string => `${' '.repeat(space)}${text}`;
 
-const getPaths = (dependencyChain: readonly string[]): string =>
-  dependencyChain.map(dependency => indentedLine(`- ${dependency}/**`, 6)).join('\n');
+const getPaths = (dependencyChain: readonly string[]): string => dependencyChain.map((dependency) => indentedLine(`- ${dependency}/**`, 6)).join('\n');
 
 const getBuildCommands = (dependencyChain: readonly string[]): string => {
   const commands: string[] = [];
-  dependencyChain.slice(0, dependencyChain.length - 1).forEach(dependency => {
+  dependencyChain.slice(0, dependencyChain.length - 1).forEach((dependency) => {
     commands.push(
       `${indentedLine(`- name: Build dependency ${dependency}`, 6)}`,
-      `${indentedLine(`  run: yarn workspace ${dependency} build`, 6)}`
+      `${indentedLine(`  run: yarn workspace ${dependency} build`, 6)}`,
     );
   });
   const workspace = dependencyChain[dependencyChain.length - 1];
   commands.push(
     `${indentedLine(`- name: Build ${workspace}`, 6)}`,
-    `${indentedLine(`  run: yarn workspace ${workspace} build`, 6)}`
+    `${indentedLine(`  run: yarn workspace ${workspace} build`, 6)}`,
   );
   return commands.join('\n');
 };
@@ -52,7 +51,7 @@ ${getBuildCommands(dependencyChain)}
 
 const generateFrontendPackageCDWorkflow = (
   workspace: string,
-  deployStepGenerator: () => string
+  deployStepGenerator: () => string,
 ): [string, string] => {
   const dependencyChain = getDependencyChain(workspace);
   const ymlContent = `# @generated
@@ -123,5 +122,5 @@ export default (): readonly [string, string][] => [
   generateBlogPackageCDWorkflow(),
   generateReactFrontendPackageCDWorkflow('main-site-frontend'),
   generateReactFrontendPackageCDWorkflow('samlang-demo-frontend'),
-  generateReactFrontendPackageCDWorkflow('ten-web-frontend')
+  generateReactFrontendPackageCDWorkflow('ten-web-frontend'),
 ];

--- a/tooling/src/generator.ts
+++ b/tooling/src/generator.ts
@@ -2,26 +2,21 @@ import { getDependencyChain } from './workspace';
 
 const indentedLine = (text: string, space: number): string => `${' '.repeat(space)}${text}`;
 
-const getPaths = (
-  dependencyChain: readonly string[],
-): string => dependencyChain.map((dependency) => indentedLine(`- ${dependency}/**`, 6)).join('\n');
+const getPaths = (dependencyChain: readonly string[]): string =>
+  dependencyChain.map(dependency => indentedLine(`- ${dependency}/**`, 6)).join('\n');
 
-const getBuildCommands = (
-  dependencyChain: readonly string[],
-): string => {
+const getBuildCommands = (dependencyChain: readonly string[]): string => {
   const commands: string[] = [];
-  dependencyChain
-    .slice(0, dependencyChain.length - 1)
-    .forEach((dependency) => {
-      commands.push(
-        `${indentedLine(`- name: Build dependency ${dependency}`, 6)}`,
-        `${indentedLine(`  run: yarn workspace ${dependency} build`, 6)}`,
-      );
-    });
+  dependencyChain.slice(0, dependencyChain.length - 1).forEach(dependency => {
+    commands.push(
+      `${indentedLine(`- name: Build dependency ${dependency}`, 6)}`,
+      `${indentedLine(`  run: yarn workspace ${dependency} build`, 6)}`
+    );
+  });
   const workspace = dependencyChain[dependencyChain.length - 1];
   commands.push(
     `${indentedLine(`- name: Build ${workspace}`, 6)}`,
-    `${indentedLine(`  run: yarn workspace ${workspace} build`, 6)}`,
+    `${indentedLine(`  run: yarn workspace ${workspace} build`, 6)}`
   );
   return commands.join('\n');
 };
@@ -35,6 +30,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/ci-workflow-${workspace}.yml
+      - package.json
       - configuration/**
       - tooling/**
 ${getPaths(dependencyChain)}
@@ -56,7 +52,7 @@ ${getBuildCommands(dependencyChain)}
 
 const generateFrontendPackageCDWorkflow = (
   workspace: string,
-  deployStepGenerator: () => string,
+  deployStepGenerator: () => string
 ): [string, string] => {
   const dependencyChain = getDependencyChain(workspace);
   const ymlContent = `# @generated
@@ -68,8 +64,9 @@ on:
       - master
     paths:
       - .github/workflows/cd-workflow-${workspace}.yml
-      - configuration/*
-      - tooling/*
+      - package.json
+      - configuration/**
+      - tooling/**
 ${getPaths(dependencyChain)}
 
 jobs:
@@ -126,5 +123,5 @@ export default (): readonly [string, string][] => [
   generateBlogPackageCDWorkflow(),
   generateReactFrontendPackageCDWorkflow('main-site-frontend'),
   generateReactFrontendPackageCDWorkflow('samlang-demo-frontend'),
-  generateReactFrontendPackageCDWorkflow('ten-web-frontend'),
+  generateReactFrontendPackageCDWorkflow('ten-web-frontend')
 ];


### PR DESCRIPTION
We can simply put them in the root package.json to keep tooling package pure.
As a result, we need to make the workflow generator to include the root package.json since now it's very important