### PR TITLE
[blog] Fix footer css bug

### DIFF
--- a/blog/src/css/custom.css
+++ b/blog/src/css/custom.css
@@ -55,7 +55,7 @@ a:active {
 }
 
 .footer {
-  position: absolute;
+  position: fixed;
   width: 100%;
   bottom: 0;
   z-index: var(--ifm-z-index-fixed);


### PR DESCRIPTION
Somehow docusaurus changes layout between alpha versions. `position: absolute` no longer works. `position: fixed;` is now necessary.