### PR TITLE
Move deploy command to NPM script

### DIFF
--- a/blog/package.json
+++ b/blog/package.json
@@ -7,7 +7,7 @@
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
-    "deploy": "docusaurus deploy"
+    "deploy": "firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting:blog"
   },
   "dependencies": {
     "@docusaurus/core": "^2.0.0-alpha.35",

--- a/builder/configuration.py
+++ b/builder/configuration.py
@@ -1,4 +1,3 @@
-import os
 from dataclasses import dataclass
 from typing import Sequence
 from .workspace import get_dependency_chain
@@ -33,19 +32,11 @@ def _create_project(
     )
 
 
-def create_yarn_workspace_project(
-    workspace: str, pre_deploy_command: Sequence[str] = []
-) -> Project:
-    deploy_command = [
-        *pre_deploy_command,
-        "./node_modules/.bin/firebase deploy"
-        + f" --token={os.environ.get('FIREBASE_TOKEN')}"
-        + f" --non-interactive --only hosting:{workspace}",
-    ]
+def create_yarn_workspace_project(workspace: str) -> Project:
     return _create_project(
         workspace=workspace,
         build_command=f"yarn workspace {workspace} build",
-        deploy_command=deploy_command,
+        deploy_command=f"yarn workspace {workspace} deploy",
         build_output=f"{workspace}/build",
         additional_dependency_paths=["package.json", "yarn.lock", "configuration/**"],
     )
@@ -57,7 +48,5 @@ def get_projects() -> Sequence[Project]:
         create_yarn_workspace_project(workspace="samlang"),
         create_yarn_workspace_project(workspace="samlang-demo"),
         create_yarn_workspace_project(workspace="ten"),
-        create_yarn_workspace_project(
-            workspace="www", pre_deploy_command=["yarn workspace www ci-postbuild"]
-        ),
+        create_yarn_workspace_project(workspace="www"),
     ]

--- a/samlang-demo/package.json
+++ b/samlang-demo/package.json
@@ -13,7 +13,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "tsc": "tsc -p tsconfig.json"
+    "tsc": "tsc -p tsconfig.json",
+    "deploy": "firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting:samlang-demo"
   },
   "browserslist": [
     ">0.2%",

--- a/samlang/package.json
+++ b/samlang/package.json
@@ -7,7 +7,7 @@
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
-    "deploy": "docusaurus deploy"
+    "deploy": "firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting:samlang"
   },
   "dependencies": {
     "@docusaurus/core": "^2.0.0-alpha.35",

--- a/ten/package.json
+++ b/ten/package.json
@@ -16,7 +16,8 @@
     "build": "react-app-rewired build",
     "test": "react-app-rewired test",
     "eject": "react-scripts eject",
-    "tsc": "tsc -p tsconfig.json"
+    "tsc": "tsc -p tsconfig.json",
+    "deploy": "firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting:ten"
   },
   "browserslist": [
     ">0.2%",

--- a/www/package.json
+++ b/www/package.json
@@ -12,10 +12,11 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "ci-postbuild": "react-snap",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "tsc": "tsc -p tsconfig.json"
+    "tsc": "tsc -p tsconfig.json",
+    "predeploy": "react-snap",
+    "deploy": "firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting:www"
   },
   "browserslist": [
     ">0.2%",


### PR DESCRIPTION
Goal for future diffs: avoid using python to run scripts, only use python to generate CI/CD yml files.