### PR TITLE
[www] No root in `FileSystemState`

### DIFF
--- a/packages/www/src/filesystem/index.ts
+++ b/packages/www/src/filesystem/index.ts
@@ -1,18 +1,4 @@
-import { FileSystemState } from './types';
 import { changeDirectory } from './stack';
 
-/**
- * Works like `cd`.
- *
- * @param state the current filesystem state of the terminal.
- * @param path the absolute or relative path to `cd` into.
- * @returns the new filesystem state.
- * @throws if it's an invalid operation.
- */
-const cd = (state: FileSystemState, path: string): FileSystemState => ({
-  root: state.root,
-  stack: changeDirectory(state.stack, path)
-});
-
 // eslint-disable-next-line import/prefer-default-export
-export { cd };
+export { changeDirectory };

--- a/packages/www/src/filesystem/initial-state.test.ts
+++ b/packages/www/src/filesystem/initial-state.test.ts
@@ -1,6 +1,6 @@
 import initialState from './initial-state';
 
 it('initialState is not messed up', () => {
-  expect(initialState.stack.length).toBe(1);
-  expect(initialState.stack[0][0]).toBe('');
+  expect(initialState.length).toBe(1);
+  expect(initialState[0][0]).toBe('');
 });

--- a/packages/www/src/filesystem/initial-state.ts
+++ b/packages/www/src/filesystem/initial-state.ts
@@ -46,5 +46,5 @@ const directoryRoot: Directory = {
 /**
  * The initial state of the file system.
  */
-const initialState: FileSystemState = { root: directoryRoot, stack: [['', directoryRoot]] };
+const initialState: FileSystemState = [['', directoryRoot]];
 export default initialState;

--- a/packages/www/src/filesystem/path.test.ts
+++ b/packages/www/src/filesystem/path.test.ts
@@ -1,4 +1,4 @@
-import { stripRoot, normalize, join, currentStackDirectoryPath } from './path';
+import { stripRoot, normalize, join, currentDirectoryPath } from './path';
 import initialState from './initial-state';
 import { changeDirectoryOneLevel } from './stack';
 
@@ -26,11 +26,11 @@ it('join works', () => {
 });
 
 it('currentDirectoryPath works', () => {
-  expect(currentStackDirectoryPath(initialState.stack)).toBe('/');
-  const topSecretStack = changeDirectoryOneLevel(initialState.stack, 'top-secret');
-  expect(currentStackDirectoryPath(topSecretStack)).toBe('/top-secret');
-  const realSecretStack = changeDirectoryOneLevel(topSecretStack, 'real-secret');
-  expect(currentStackDirectoryPath(realSecretStack)).toBe('/top-secret/real-secret');
-  const randomStack = changeDirectoryOneLevel(realSecretStack, 'random');
-  expect(currentStackDirectoryPath(randomStack)).toBe('/top-secret/real-secret/random');
+  expect(currentDirectoryPath(initialState)).toBe('/');
+  const topSecretState = changeDirectoryOneLevel(initialState, 'top-secret');
+  expect(currentDirectoryPath(topSecretState)).toBe('/top-secret');
+  const realSecretState = changeDirectoryOneLevel(topSecretState, 'real-secret');
+  expect(currentDirectoryPath(realSecretState)).toBe('/top-secret/real-secret');
+  const randomState = changeDirectoryOneLevel(realSecretState, 'random');
+  expect(currentDirectoryPath(randomState)).toBe('/top-secret/real-secret/random');
 });

--- a/packages/www/src/filesystem/path.ts
+++ b/packages/www/src/filesystem/path.ts
@@ -1,4 +1,4 @@
-import { DirectoryStack, FileSystemState } from './types';
+import { FileSystemState } from './types';
 
 export const stripRoot = (path: string): string =>
   path.startsWith('/') ? path.substring(1) : path;
@@ -16,18 +16,10 @@ export const join = (segment1: string, segment2: string): string =>
 
 /**
  *
- * @param state the current stack.
- * @returns a string representation of the current directory path.
- */
-export const currentStackDirectoryPath = (stack: DirectoryStack): string => {
-  const simpleAnswer = stack.map(([pathSegment]) => pathSegment).join('/');
-  return simpleAnswer === '' ? '/' : simpleAnswer;
-};
-
-/**
- *
  * @param state the current filesystem state of the terminal.
  * @returns a string representation of the current directory path.
  */
-export const currentDirectoryPath = ({ stack }: FileSystemState): string =>
-  currentStackDirectoryPath(stack);
+export const currentDirectoryPath = (state: FileSystemState): string => {
+  const simpleAnswer = state.map(([pathSegment]) => pathSegment).join('/');
+  return simpleAnswer === '' ? '/' : simpleAnswer;
+};

--- a/packages/www/src/filesystem/stack.test.ts
+++ b/packages/www/src/filesystem/stack.test.ts
@@ -2,9 +2,9 @@ import initialState from './initial-state';
 import { changeDirectoryOneLevel, changeDirectory } from './stack';
 
 it('changeDirectoryOneLevel works forward and backward', () => {
-  expect(changeDirectoryOneLevel(initialState.stack, '..')).toStrictEqual(initialState.stack);
-  const topSecretState = changeDirectoryOneLevel(initialState.stack, 'top-secret');
-  expect(changeDirectoryOneLevel(topSecretState, '..')).toStrictEqual(initialState.stack);
+  expect(changeDirectoryOneLevel(initialState, '..')).toStrictEqual(initialState);
+  const topSecretState = changeDirectoryOneLevel(initialState, 'top-secret');
+  expect(changeDirectoryOneLevel(topSecretState, '..')).toStrictEqual(initialState);
   const realSecretState = changeDirectoryOneLevel(topSecretState, 'real-secret');
   expect(changeDirectoryOneLevel(realSecretState, '..')).toStrictEqual(topSecretState);
   const randomState = changeDirectoryOneLevel(realSecretState, 'random');
@@ -12,10 +12,10 @@ it('changeDirectoryOneLevel works forward and backward', () => {
 });
 
 it('changeDirectoryOneLevel should crash when given bad filename', () => {
-  expect(() => changeDirectoryOneLevel(initialState.stack, 'garbage')).toThrow(
+  expect(() => changeDirectoryOneLevel(initialState, 'garbage')).toThrow(
     'garbage is not found in directory: `/`.'
   );
-  expect(() => changeDirectoryOneLevel(initialState.stack, 'README.md')).toThrow(
+  expect(() => changeDirectoryOneLevel(initialState, 'README.md')).toThrow(
     '`/README.md` is not a directory.'
   );
 });
@@ -25,7 +25,7 @@ it('changeDirectory integration test can pass', () => {
     changeDirectory(
       changeDirectory(
         changeDirectory(
-          changeDirectory(changeDirectory(initialState.stack, 'top-secret/real-secret/'), '../../'),
+          changeDirectory(changeDirectory(initialState, 'top-secret/real-secret/'), '../../'),
           '/top-secret/real-secret/'
         ),
         '../'
@@ -34,6 +34,6 @@ it('changeDirectory integration test can pass', () => {
     ),
     '../../.././top-secret/../top-secret/../top-secret/real-secret/../'
   );
-  const stateAfterSimpleOperation = changeDirectory(initialState.stack, '/top-secret/');
+  const stateAfterSimpleOperation = changeDirectory(initialState, '/top-secret/');
   expect(stateAfterComplexOperations).toStrictEqual(stateAfterSimpleOperation);
 });

--- a/packages/www/src/filesystem/stack.ts
+++ b/packages/www/src/filesystem/stack.ts
@@ -1,55 +1,53 @@
-import { DirectoryStack } from './types';
-import { normalize, join, currentStackDirectoryPath } from './path';
+import { FileSystemState } from './types';
+import { normalize, join, currentDirectoryPath } from './path';
 
 /**
  * Change the directory stack for one level.
  *
- * @param stack the current directory stack.
+ * @param state the current filesystem state of the terminal.
  * @param filename the filename of the directory to go into.
- * @returns the new directory stack.
+ * @returns the new filesystem state.
  * @throws if it's an invalid operation.
  */
 export const changeDirectoryOneLevel = (
-  stack: DirectoryStack,
+  state: FileSystemState,
   filename: string
-): DirectoryStack => {
+): FileSystemState => {
   if (filename === '.') {
-    return stack;
+    return state;
   }
   if (filename === '..') {
-    return stack.length <= 1 ? stack : stack.slice(0, stack.length - 1);
+    return state.length <= 1 ? state : state.slice(0, state.length - 1);
   }
-  const currentDirectory = stack[stack.length - 1][1];
+  const currentDirectory = state[state.length - 1][1];
   const foundFileWithName = currentDirectory.children.find(
     ([localFilename]) => localFilename === filename
   );
   if (foundFileWithName == null) {
-    throw new Error(
-      `${filename} is not found in directory: \`${currentStackDirectoryPath(stack)}\`.`
-    );
+    throw new Error(`${filename} is not found in directory: \`${currentDirectoryPath(state)}\`.`);
   }
   const foundFile = foundFileWithName[1];
   if (foundFile.type === 'TEXT_FILE') {
-    throw new Error(`\`${join(currentStackDirectoryPath(stack), filename)}\` is not a directory.`);
+    throw new Error(`\`${join(currentDirectoryPath(state), filename)}\` is not a directory.`);
   }
-  return [...stack, [filename, foundFile]];
+  return [...state, [filename, foundFile]];
 };
 
 /**
  * Change the directory stack according to `path`.
  *
- * @param stack the current filesystem state of the terminal.
+ * @param state the current filesystem state of the terminal.
  * @param path the absolute or relative path to `cd` into.
- * @returns the new directory stack.
+ * @returns the new filesystem state.
  * @throws if it's an invalid operation.
  */
-export const changeDirectory = (stack: DirectoryStack, path: string): DirectoryStack => {
+export const changeDirectory = (state: FileSystemState, path: string): FileSystemState => {
   if (path.startsWith('/')) {
     // The case for absolute directory.
     // We start from root, and then use the same relative algorithm.
-    return changeDirectory(stack, path.substring(1));
+    return changeDirectory(state, path.substring(1));
   }
   return normalize(path)
     .split('/')
-    .reduce((accumulator, filename) => changeDirectoryOneLevel(accumulator, filename), stack);
+    .reduce((accumulator, filename) => changeDirectoryOneLevel(accumulator, filename), state);
 };

--- a/packages/www/src/filesystem/types.ts
+++ b/packages/www/src/filesystem/types.ts
@@ -4,8 +4,5 @@ export type Directory = {
   readonly type: 'DIRECTORY';
   readonly children: readonly [string, File][];
 };
-export type DirectoryStack = readonly [string, Directory][];
-export type FileSystemState = {
-  readonly root: Directory;
-  readonly stack: DirectoryStack;
-};
+
+export type FileSystemState = readonly [string, Directory][];


### PR DESCRIPTION
We don't actually need this explicit root. The first, unremovable item in the stack already contains the root. Since we use the immutable stack approach, it's never mutated, so we are always safe.