### PR TITLE
[www][terminal] Implement command autocompletion

### DIFF
--- a/packages/www/src/components/WebTerminal/Terminal.tsx
+++ b/packages/www/src/components/WebTerminal/Terminal.tsx
@@ -2,6 +2,7 @@
 
 import React, { ReactElement, KeyboardEvent, useRef, useState } from 'react';
 import { TerminalHistory } from './types';
+import autoComplete from './auto-complete';
 import commands from './commands';
 import scrollHistory from './history';
 import styles from './Terminal.module.css';
@@ -85,6 +86,13 @@ export default (): ReactElement => {
       return { ...oldState, ...update };
     });
 
+  const autoCompleteCommand = (): void => {
+    const inputNode = terminalInput.current;
+    if (inputNode != null) {
+      inputNode.value = autoComplete(Object.keys(commands), inputNode.value);
+    }
+  };
+
   const handleInput = (event: KeyboardEvent<HTMLInputElement>) => {
     switch (event.key) {
       case 'Enter':
@@ -95,6 +103,10 @@ export default (): ReactElement => {
         break;
       case 'ArrowDown':
         historyUpDown('down');
+        break;
+      case 'Tab':
+        event.preventDefault();
+        autoCompleteCommand();
         break;
       default:
         break;

--- a/packages/www/src/components/WebTerminal/auto-complete.test.ts
+++ b/packages/www/src/components/WebTerminal/auto-complete.test.ts
@@ -1,0 +1,42 @@
+import autoComplete, { autoCompleteOnePart } from './auto-complete';
+
+it('autoCompleteOnePart works', () => {
+  // One choice cases
+  expect(autoCompleteOnePart(['foo', 'bar'], 'f')).toBe('foo');
+  expect(autoCompleteOnePart(['foo', 'bar'], 'fo')).toBe('foo');
+  expect(autoCompleteOnePart(['foo', 'bar'], 'foo')).toBe('foo');
+  expect(autoCompleteOnePart(['foo', 'bar'], 'b')).toBe('bar');
+  expect(autoCompleteOnePart(['foo', 'bar'], 'ba')).toBe('bar');
+  expect(autoCompleteOnePart(['foo', 'bar'], 'bar')).toBe('bar');
+  // Multuple choices cases
+  expect(autoCompleteOnePart(['idea', 'ideology'], 'id')).toBe('ide');
+  // No choices cases
+  expect(autoCompleteOnePart(['foo', 'bar', 'idea', 'ideology'], 'random')).toBe(null);
+  // Empty string cases
+  expect(autoCompleteOnePart(['foo', 'bar'], '')).toBe('');
+});
+
+it('autoComplete works', () => {
+  // One choice cases
+  expect(autoComplete(['foo', 'bar'], 'f')).toBe('foo');
+  expect(autoComplete(['foo', 'bar'], 'fo')).toBe('foo');
+  expect(autoComplete(['foo', 'bar'], 'foo')).toBe('foo');
+  expect(autoComplete(['foo', 'bar'], 'b')).toBe('bar');
+  expect(autoComplete(['foo', 'bar'], 'ba')).toBe('bar');
+  expect(autoComplete(['foo', 'bar'], 'bar')).toBe('bar');
+  expect(autoComplete(['foo', 'bar'], 'command f')).toBe('command foo');
+  expect(autoComplete(['foo', 'bar'], 'command fo')).toBe('command foo');
+  expect(autoComplete(['foo', 'bar'], 'command foo')).toBe('command foo');
+  expect(autoComplete(['foo', 'bar'], 'command b')).toBe('command bar');
+  expect(autoComplete(['foo', 'bar'], 'command ba')).toBe('command bar');
+  expect(autoComplete(['foo', 'bar'], 'command bar')).toBe('command bar');
+  // Multuple choices cases
+  expect(autoComplete(['idea', 'ideology'], 'id')).toBe('ide');
+  expect(autoComplete(['idea', 'ideology'], 'command id')).toBe('command ide');
+  // No choices cases
+  expect(autoComplete(['foo', 'bar', 'idea', 'ideology'], 'random')).toBe('random');
+  expect(autoComplete(['foo', 'bar', 'idea', 'ideology'], 'foo random')).toBe('foo random');
+  expect(autoComplete(['foo', 'bar', 'idea', 'ideology'], ' foo random ')).toBe('foo random');
+  // Empty string cases
+  expect(autoComplete(['foo', 'bar'], '')).toBe('');
+});

--- a/packages/www/src/components/WebTerminal/auto-complete.ts
+++ b/packages/www/src/components/WebTerminal/auto-complete.ts
@@ -1,0 +1,50 @@
+/**
+ * @param sources a list of strings that can be used to expand the prefix.
+ * @param prefix the prefix to expand. No whitespace should be in the string.
+ * @returns expanded prefix string, or `null` if autocompletion failed.
+ */
+export const autoCompleteOnePart = (sources: readonly string[], prefix: string): string | null => {
+  const matchedPrefix = sources.filter(source => source.startsWith(prefix));
+  if (matchedPrefix.length === 0) {
+    return null;
+  }
+  if (matchedPrefix.length === 1) {
+    return matchedPrefix[0];
+  }
+  let bestPrefix = prefix;
+  for (let i = prefix.length; ; i += 1) {
+    const characterSet = new Set<string>();
+    for (let j = 0; j < matchedPrefix.length; j += 1) {
+      const source = matchedPrefix[j];
+      if (i >= source.length) {
+        return bestPrefix;
+      }
+      characterSet.add(source.charAt(i));
+    }
+    if (characterSet.size < 1) {
+      throw new Error('Impossible!');
+    }
+    if (characterSet.size > 1) {
+      // Choosing either one means loss of generality. We stop here.
+      return bestPrefix;
+    }
+    bestPrefix += Array.from(characterSet.entries())[0][0];
+  }
+};
+
+/**
+ * @param sources a list of strings that can be used to expand the prefix.
+ * @param prefix the line to expand.
+ * @returns expanded line.
+ */
+const autoCompleteCommandLine = (sources: readonly string[], line: string): string => {
+  const parts = line.trim().split(' ');
+  if (parts.length === 0) {
+    return '';
+  }
+  const result = autoCompleteOnePart(sources, parts[parts.length - 1]);
+  const finalPart = result === null ? parts[parts.length - 1] : result;
+  return [...parts.slice(0, parts.length - 1), finalPart].join(' ').trim();
+};
+
+export default autoCompleteCommandLine;


### PR DESCRIPTION
Auto-completing command is very straightforward: a simple trie would work. (although I didn't actually introduce one, since number of supported commands is bounded above by a small constant).
Filename autocompletion might be more involved. Delay this until we have the infra ready.