### PR TITLE
[www][terminal] More complete `path.getParent()` fix

### DIFF
--- a/packages/www/src/filesystem/path.test.ts
+++ b/packages/www/src/filesystem/path.test.ts
@@ -17,9 +17,11 @@ it('normalize works', () => {
 });
 
 it('getParent works', () => {
-  expect(getParent('foo')).toBe('/');
+  expect(getParent('foo')).toBe('.');
+  expect(getParent('/foo')).toBe('/');
   expect(getParent('foo/bar')).toBe('foo');
-  expect(getParent('foo/')).toBe('/');
+  expect(getParent('foo/')).toBe('.');
+  expect(getParent('/foo/')).toBe('/');
   expect(getParent('foo/bar/')).toBe('foo');
 });
 

--- a/packages/www/src/filesystem/path.ts
+++ b/packages/www/src/filesystem/path.ts
@@ -8,6 +8,9 @@ export const normalize = (path: string): string =>
 
 export const getParent = (path: string): string => {
   const normalizedPath = normalize(path);
+  if (normalizedPath.indexOf('/') === -1) {
+    return '.';
+  }
   const index = normalizedPath.lastIndexOf('/');
   const result = normalize(index === -1 ? '/' : normalizedPath.substring(0, index));
   return result === '' ? '/' : result;

--- a/packages/www/src/filesystem/show-file.ts
+++ b/packages/www/src/filesystem/show-file.ts
@@ -17,7 +17,7 @@ export const showFileInDirectory = (directory: Directory, filename: string): str
 const showFiles = (state: FileSystemState, pathList: readonly string[]): string => {
   return pathList
     .map(path => {
-      const parent = path.indexOf('/') === -1 ? '.' : getParent(path);
+      const parent = getParent(path);
       const stack = parent === '/' ? initialState : changeDirectory(state, parent);
       const directory = peek(stack)[1];
       const filename = getLast(path);


### PR DESCRIPTION
#233 tries to fix it in `show-file.ts`. However, it's better to upstream the fix.