### PR TITLE
[www] Fix size of the first page code block

### DIFF
--- a/packages/www/src/components/FirstPage/FirstPageCodeBlock.module.css
+++ b/packages/www/src/components/FirstPage/FirstPageCodeBlock.module.css
@@ -1,4 +1,6 @@
 .Block {
+  width: 450px;
+  height: 670px;
   line-height: 1.5em;
 }
 

--- a/packages/www/src/components/FirstPage/__snapshots__/index.test.tsx.snap
+++ b/packages/www/src/components/FirstPage/__snapshots__/index.test.tsx.snap
@@ -8,8 +8,8 @@ exports[`FirstPage matches snapshot. 1`] = `
   <div
     style={
       Object {
-        "height": "660px",
-        "width": "430px",
+        "height": "670px",
+        "width": "450px",
       }
     }
   >

--- a/packages/www/src/components/FirstPage/index.tsx
+++ b/packages/www/src/components/FirstPage/index.tsx
@@ -28,7 +28,7 @@ const IconLine = ({ Icon, children }: IconLineProps): ReactElement => (
 
 export default (): ReactElement => (
   <div id="about" className={styles.FirstPage}>
-    <Suspense fallback={<div style={{ width: '430px', height: '660px' }}>Loading...</div>}>
+    <Suspense fallback={<div style={{ width: '450px', height: '670px' }}>Loading...</div>}>
       <FirstPageCodeBlock />
     </Suspense>
     <Card className={styles.InfoCard}>


### PR DESCRIPTION
When the size is fixed, we can confidently hard code the fallback div's size. Now there will be no jumping during initial page load.