### PR TITLE
[ci] Reduce CI build time

### DIFF
--- a/.github/workflows/generated-ci-blog.yml
+++ b/.github/workflows/generated-ci-blog.yml
@@ -26,5 +26,5 @@ jobs:
           restore-keys: yarn-
       - name: Yarn Install
         run: yarn install
-      - name: Build
-        run: yarn workspace blog build
+      - name: Compile
+        run: yarn workspace blog compile

--- a/.github/workflows/generated-ci-samlang-demo.yml
+++ b/.github/workflows/generated-ci-samlang-demo.yml
@@ -26,5 +26,5 @@ jobs:
           restore-keys: yarn-
       - name: Yarn Install
         run: yarn install
-      - name: Build
-        run: yarn workspace samlang-demo build
+      - name: Compile
+        run: yarn workspace samlang-demo compile

--- a/.github/workflows/generated-ci-samlang.yml
+++ b/.github/workflows/generated-ci-samlang.yml
@@ -26,5 +26,5 @@ jobs:
           restore-keys: yarn-
       - name: Yarn Install
         run: yarn install
-      - name: Build
-        run: yarn workspace samlang build
+      - name: Compile
+        run: yarn workspace samlang compile

--- a/.github/workflows/generated-ci-ten.yml
+++ b/.github/workflows/generated-ci-ten.yml
@@ -26,5 +26,5 @@ jobs:
           restore-keys: yarn-
       - name: Yarn Install
         run: yarn install
-      - name: Build
-        run: yarn workspace ten build
+      - name: Compile
+        run: yarn workspace ten compile

--- a/.github/workflows/generated-ci-www.yml
+++ b/.github/workflows/generated-ci-www.yml
@@ -26,5 +26,5 @@ jobs:
           restore-keys: yarn-
       - name: Yarn Install
         run: yarn install
-      - name: Build
-        run: yarn workspace www build
+      - name: Compile
+        run: yarn workspace www compile

--- a/.github/workflows/test-js-ts.yml
+++ b/.github/workflows/test-js-ts.yml
@@ -2,7 +2,7 @@ name: test-js-ts
 on:
   push:
     paths:
-      - '.github/workflows/lint-js-ts.yml'
+      - '.github/workflows/test-js-ts.yml'
       - '**.js'
       - '**.ts'
       - '**.jsx'

--- a/packages/blog/package.json
+++ b/packages/blog/package.json
@@ -7,6 +7,7 @@
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
+    "compile": "yarn build",
     "test": "echo 'No tests yet.'",
     "deploy": "firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting:blog"
   },

--- a/packages/lib-react-test/package.json
+++ b/packages/lib-react-test/package.json
@@ -8,6 +8,7 @@
     "react-dom": "^16.12.0"
   },
   "scripts": {
+    "compile": "tsc -p tsconfig.json",
     "test": "react-scripts test --watchAll=false"
   }
 }

--- a/packages/lib-react/package.json
+++ b/packages/lib-react/package.json
@@ -10,6 +10,7 @@
   "private": true,
   "scripts": {
     "dev": "tsc --incremental --watch",
+    "compile": "tsc",
     "build": "tsc --incremental",
     "postinstall": "yarn build",
     "test": "echo 'Tests are in lib-react-test.'"

--- a/packages/samlang-demo/package.json
+++ b/packages/samlang-demo/package.json
@@ -13,7 +13,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject",
-    "tsc": "tsc -p tsconfig.json",
+    "compile": "tsc -p tsconfig.json",
     "deploy": "firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting:samlang-demo"
   },
   "browserslist": [

--- a/packages/samlang-demo/src/LanguageDemo/ResultCard.test.tsx
+++ b/packages/samlang-demo/src/LanguageDemo/ResultCard.test.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { Response } from './interpret';
 import ResultCard from './ResultCard';
 
 it('ResultCard(GOOD_PROGRAM) matches snapshot.', () => {
-  const response = {
+  const response: Response = {
     type: 'GOOD_PROGRAM',
     detail: { result: 'haha', prettyPrintedProgram: 'class HelloWorld {}' }
   };

--- a/packages/samlang/package.json
+++ b/packages/samlang/package.json
@@ -7,6 +7,7 @@
     "start": "docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
+    "compile": "yarn build",
     "test": "echo 'No tests yet.'",
     "deploy": "firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting:samlang"
   },

--- a/packages/ten/package.json
+++ b/packages/ten/package.json
@@ -16,7 +16,7 @@
     "build": "react-app-rewired build",
     "test": "react-app-rewired test --watchAll=false",
     "eject": "react-scripts eject",
-    "tsc": "tsc -p tsconfig.json",
+    "compile": "tsc -p tsconfig.json",
     "deploy": "firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting:ten"
   },
   "browserslist": [

--- a/packages/www/package.json
+++ b/packages/www/package.json
@@ -17,7 +17,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject",
-    "tsc": "tsc -p tsconfig.json",
+    "compile": "tsc -p tsconfig.json",
     "deploy": "react-snap && firebase deploy --token=$FIREBASE_TOKEN --non-interactive --only hosting:www"
   },
   "browserslist": [

--- a/tools/generate
+++ b/tools/generate
@@ -54,8 +54,8 @@ on:
 ${getPathsString(workspace)}
 
 ${getBoilterPlateSetupSteps('build')}
-      - name: Build
-        run: yarn workspace ${workspace} build
+      - name: Compile
+        run: yarn workspace ${workspace} compile
 `;
   return [filename, content];
 };


### PR DESCRIPTION
For all CRA projects, the build process involves basic linting and webpack building. Webpack building may run some TSC check.
For all docusaurus projects, the build process only involves webpack building.
Currently, the CI is wasting a lot of time building stuff that is known to be good. The only exception is docusaurus building. (Since it's still in alpha, nothing is so sure.)
Therefore, I introduced a `compile` job to replace the build job. It only runs `tsc` for CRA projects but fallbacks to `yarn build` for docusaurus projects. Now we no longer need to pay for the same spent on running useless minimization for CI build.