### PR TITLE
[repo] Add prose wrap format for prettier

### DIFF
--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,3 +1,4 @@
 printWidth: 100
 singleQuote: true
 endOfLine: lf
+proseWrap: always


### PR DESCRIPTION
In this repo, we never use line-break sensitive processors. Instead, we do enforce line-width. Let's add this to help markdown writing.