### PR TITLE
[blog] Completely disable dark mode for blog

### DIFF
--- a/packages/blog/docusaurus.config.js
+++ b/packages/blog/docusaurus.config.js
@@ -14,6 +14,7 @@ module.exports = {
   baseUrl: '/',
   favicon: 'https://developersam.com/favicon.ico',
   themeConfig: {
+    disableDarkMode: true,
     navbar: {
       title: 'Developer Sam Blog',
       links: [


### PR DESCRIPTION
It's not built with dark mode in mind.
The site looks broken in dark mode.
Maintaining it while keep up-to-date with Docusaurus alpha is not worth it.