### PR TITLE
[repo] Simplify linter configurations

### DIFF
--- a/configuration/next-config-overrider.js
+++ b/configuration/next-config-overrider.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
 const withTM = require('next-transpile-modules');
 
 const libraries = require('./libraries.json');

--- a/packages/blog/docusaurus.config.js
+++ b/packages/blog/docusaurus.config.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const theme = require('lib-react/prism-theme.json');
 
 module.exports = {

--- a/packages/eslint-config-common/index.js
+++ b/packages/eslint-config-common/index.js
@@ -8,11 +8,7 @@ module.exports = {
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'jest'],
   rules: {
-    '@typescript-eslint/explicit-function-return-type': 'off', // Too noisy
-    '@typescript-eslint/indent': 'off', // Already covered by Prettier
-    '@typescript-eslint/no-angle-bracket-type-assertion': 'off',
     '@typescript-eslint/no-empty-function': 'off',
-    '@typescript-eslint/no-object-literal-type-assertion': 'off',
     '@typescript-eslint/no-require-imports': 'error',
     '@typescript-eslint/no-unused-vars': [
       'error',
@@ -23,7 +19,6 @@ module.exports = {
         varsIgnorePattern: '_',
       },
     ],
-    '@typescript-eslint/prefer-interface': 'off',
     'import/extensions': 'off',
     'import/no-unresolved': [
       'error',
@@ -56,6 +51,7 @@ module.exports = {
     'react/prop-types': 'off',
     'react/jsx-indent': 'off', // Already covered by Prettier
     'react/jsx-one-expression-per-line': 'off',
+    'spaced-comment': ['error', 'always', { markers: ['/'] }],
   },
   settings: {
     'import/resolver': {
@@ -68,8 +64,8 @@ module.exports = {
     {
       files: ['*.js', '*.jsx'],
       rules: {
+        '@typescript-eslint/no-require-imports': 'off',
         '@typescript-eslint/no-var-requires': 'off',
-        '@typescript-eslint/no-unused-vars': 'off',
       },
     },
   ],

--- a/packages/lib-docusaurus-plugin/prism-include-languages.js
+++ b/packages/lib-docusaurus-plugin/prism-include-languages.js
@@ -1,5 +1,4 @@
 /* eslint-disable global-require */
-/* eslint-disable @typescript-eslint/no-require-imports */
 import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 import Prism from 'prism-react-renderer/prism';
 

--- a/packages/lib-react/PrismCodeBlock.tsx
+++ b/packages/lib-react/PrismCodeBlock.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-require-imports */
 import React, { ReactElement, CSSProperties } from 'react';
 
 import Highlight, { defaultProps, Language, PrismTheme } from 'prism-react-renderer';

--- a/packages/samlang/docusaurus.config.js
+++ b/packages/samlang/docusaurus.config.js
@@ -5,10 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const darkTheme = require('prism-react-renderer/themes/dracula');
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const theme = require('lib-react/prism-theme.json');
 
 module.exports = {

--- a/packages/samlang/src/types.d.ts
+++ b/packages/samlang/src/types.d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable spaced-comment */
 /// <reference types="react" />
 /// <reference types="@docusaurus/module-type-aliases" />
 

--- a/packages/tasks/next-env.d.ts
+++ b/packages/tasks/next-env.d.ts
@@ -1,3 +1,2 @@
-/* eslint-disable spaced-comment */
 /// <reference types="next" />
 /// <reference types="next/types/global" />

--- a/packages/tasks/next.config.js
+++ b/packages/tasks/next.config.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 module.exports = require('../../configuration/next-config-overrider')();

--- a/packages/ten/next-env.d.ts
+++ b/packages/ten/next-env.d.ts
@@ -1,3 +1,2 @@
-/* eslint-disable spaced-comment */
 /// <reference types="next" />
 /// <reference types="next/types/global" />

--- a/packages/ten/next.config.js
+++ b/packages/ten/next.config.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 module.exports = require('../../configuration/next-config-overrider')();

--- a/packages/www/components/TimelineSection/TimelineItemCard.tsx
+++ b/packages/www/components/TimelineSection/TimelineItemCard.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/no-array-index-key */
-
 import React, { ReactElement } from 'react';
 
 import Card from '@material-ui/core/Card';
@@ -51,6 +49,7 @@ export default ({ item: { title, type, time, image, detail, links } }: Props): R
             <CardActions>
               {links.map(
                 ({ name, url }, index): ReactElement => (
+                  // eslint-disable-next-line react/no-array-index-key
                   <MaterialButtonLink key={index} href={url}>
                     {name}
                   </MaterialButtonLink>

--- a/packages/www/components/TimelineSection/index.tsx
+++ b/packages/www/components/TimelineSection/index.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable react/no-array-index-key */
-
 import React, { ReactElement } from 'react';
 
 import Checkbox from '@material-ui/core/Checkbox';
@@ -85,6 +83,7 @@ export const TimelineSection = ({
         <div className={styles.VerticalBar} />
         {filteredItems.map(
           (item, index): ReactElement => (
+            // eslint-disable-next-line react/no-array-index-key
             <TimelineItemCard key={index} item={item} />
           )
         )}

--- a/packages/www/next-env.d.ts
+++ b/packages/www/next-env.d.ts
@@ -1,3 +1,2 @@
-/* eslint-disable spaced-comment */
 /// <reference types="next" />
 /// <reference types="next/types/global" />

--- a/packages/www/next.config.js
+++ b/packages/www/next.config.js
@@ -1,2 +1,1 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 module.exports = require('../../configuration/next-config-overrider')();


### PR DESCRIPTION
Bump of `@typescript-eslint` to 3.0 can lead to a lot of simplications. A lot of bad rules are no longer in recommended.