### PR TITLE
[repo] Make dependabot bump github actions

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+ 


### PR DESCRIPTION
They will all sadly result in CI failure due to codegen setup, but it can at least remind me that there are updates.