### PR TITLE
[linter] Remove airbnb config

### DIFF
--- a/configuration/next-config-overrider.js
+++ b/configuration/next-config-overrider.js
@@ -6,10 +6,7 @@ module.exports = (additionalConfigurations = {}) =>
   withTM(libraries)({
     webpack(config) {
       // eslint-disable-next-line no-param-reassign
-      config.node = {
-        fs: 'empty',
-        child_process: 'empty',
-      };
+      config.node = { fs: 'empty', child_process: 'empty' };
       return config;
     },
     ...additionalConfigurations,

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const libraries = require('./configuration/libraries.json');
 
 const babelJestPath = require.resolve('babel-jest');

--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
     "@typescript-eslint/parser": "^3.8.0",
     "babel-jest": "^26.2.2",
     "eslint": "^7.6.0",
-    "eslint-config-airbnb-base": "^14.2.0",
-    "eslint-config-prettier": "^6.11.0",
     "eslint-import-resolver-node": "^0.3.4",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",

--- a/packages/blog/types.d.ts
+++ b/packages/blog/types.d.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line spaced-comment
 /// <reference types="@docusaurus/module-type-aliases" />

--- a/packages/eslint-config-common/index.js
+++ b/packages/eslint-config-common/index.js
@@ -27,13 +27,12 @@ module.exports = {
     Deno: 'readonly',
   },
   extends: [
+    'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
-    require.resolve('eslint-config-airbnb-base'),
-    require.resolve('eslint-config-prettier'),
     ...[jsxA11Y, react].filter(Boolean).map((packageName) => `plugin:${packageName}/recommended`),
   ],
   parser: require.resolve('@typescript-eslint/parser'),
-  plugins: ['@typescript-eslint', ...[jsxA11Y, react, reactHooks].filter(Boolean)],
+  plugins: ['@typescript-eslint', 'import', ...[jsxA11Y, react, reactHooks].filter(Boolean)],
   rules: {
     '@typescript-eslint/ban-ts-comment': ['error', { 'ts-expect-error': 'allow-with-description' }],
     '@typescript-eslint/no-empty-function': 'off',
@@ -47,42 +46,85 @@ module.exports = {
         varsIgnorePattern: '_',
       },
     ],
-    'import/named': 'off', // Covered by TypeScript
-    'import/no-cycle': 'off', // Too slow
-    'import/no-named-as-default': 'off', // Too slow
-    'import/no-named-as-default-member': 'off', // Covered by TypeScript
-    'import/extensions': 'off', // Too noisy
-    'import/no-unresolved': [
+    complexity: 'off',
+    'class-methods-use-this': 'error',
+    'consistent-return': 'error',
+    curly: ['error', 'multi-line'],
+    eqeqeq: ['error', 'always', { null: 'ignore' }],
+    'guard-for-in': 'error',
+    'import/first': 'error',
+    'import/prefer-default-export': 'error',
+    'import/no-absolute-path': 'error',
+    'import/no-anonymous-default-export': 'error',
+    'import/no-duplicates': 'error',
+    'import/no-dynamic-require': 'error',
+    'import/no-extraneous-dependencies': [
       'error',
       {
-        // eslint-disable-next-line no-useless-concat
-        ignore: ['^@theme', '^@docusaurus', '^@' + 'generated'],
+        devDependencies: [
+          '**/__tests__/**', // jest pattern
+          '**/*{.,_}{test,spec}.{ts,tsx}', // tests where the extension or filename suffix denotes that it is a test
+          '**/*.js', // Most code is in TS. JS code is usually for devDependencies
+        ],
+        peerDependencies: true,
+        optionalDependencies: false,
       },
     ],
-    'import/no-anonymous-default-export': 'error',
-    'import/no-extraneous-dependencies': 'off',
+    'import/no-named-default': 'error',
     'import/order': [
       'error',
       {
         groups: ['builtin', 'external', ['parent', 'sibling', 'index']],
         // Make React always appear first.
-        pathGroups: [
-          {
-            pattern: 'react?(-dom)',
-            group: 'external',
-            position: 'before',
-          },
-        ],
+        pathGroups: [{ pattern: 'react?(-dom)', group: 'external', position: 'before' }],
         pathGroupsExcludedImportTypes: ['builtin'],
         'newlines-between': 'always',
         alphabetize: { order: 'asc', caseInsensitive: false },
       },
     ],
-    indent: 'off', // Already covered by Prettier
+    'no-alert': 'warn',
+    'no-await-in-loop': 'error',
+    'no-console': 'warn',
+    'no-constant-condition': 'warn',
+    'no-empty-function': 'off',
+    'no-eq-null': 'off',
+    'no-eval': 'error',
+    'no-implicit-coercion': ['off', { boolean: false, number: true, string: true, allow: [] }],
+    'no-implied-eval': 'error',
+    'no-labels': ['error', { allowLoop: false, allowSwitch: false }],
+    'no-lone-blocks': 'error',
+    'no-param-reassign': ['error', { props: true }],
+    'no-proto': 'error',
+    'no-restricted-properties': [
+      'error',
+      { object: 'arguments', property: 'callee', message: 'arguments.callee is deprecated' },
+      { object: 'global', property: 'isFinite', message: 'Please use Number.isFinite instead' },
+      { object: 'self', property: 'isFinite', message: 'Please use Number.isFinite instead' },
+      { object: 'window', property: 'isFinite', message: 'Please use Number.isFinite instead' },
+      { object: 'global', property: 'isNaN', message: 'Please use Number.isNaN instead' },
+      { object: 'self', property: 'isNaN', message: 'Please use Number.isNaN instead' },
+      { object: 'window', property: 'isNaN', message: 'Please use Number.isNaN instead' },
+      { property: '__defineGetter__', message: 'Please use Object.defineProperty instead.' },
+      { property: '__defineSetter__', message: 'Please use Object.defineProperty instead.' },
+      { object: 'Math', property: 'pow', message: 'Use the exponentiation operator (**) instead.' },
+    ],
+    'no-return-assign': ['error', 'always'],
+    'no-self-compare': 'error',
+    'no-sequences': 'error',
+    'no-shadow': 'error',
+    'no-shadow-restricted-names': 'error',
+    'no-template-curly-in-string': 'error',
+    'no-throw-literal': 'error',
     'no-underscore-dangle': 'off',
+    'no-useless-constructor': 'error',
+    'no-useless-return': 'error',
     'no-use-before-define': 'off', // Already covered by TypeScript
     'no-unused-expressions': 'off', // Already covered by typescript-eslint
-    'object-curly-newline': 'off', // Already covered by Prettier
+    'no-var': 'error',
+    'object-shorthand': ['error', 'always', { ignoreConstructors: false, avoidQuotes: true }],
+    'prefer-const': ['error', { destructuring: 'any', ignoreReadBeforeAssign: true }],
+    'prefer-template': 'error',
+    radix: 'error',
     // Need for .d.ts type references
     'spaced-comment': ['error', 'always', { markers: ['/'] }],
     ...(react
@@ -94,10 +136,7 @@ module.exports = {
         }
       : {}),
     ...(reactHooks
-      ? {
-          'react-hooks/exhaustive-deps': 'error',
-          'react-hooks/rules-of-hooks': 'error',
-        }
+      ? { 'react-hooks/exhaustive-deps': 'error', 'react-hooks/rules-of-hooks': 'error' }
       : {}),
   },
   settings: {
@@ -106,13 +145,7 @@ module.exports = {
         extensions: ['.js', '.json', '.mjs', '.ts', '.tsx'],
       },
     },
-    ...(react
-      ? {
-          react: {
-            version: '16.13.0',
-          },
-        }
-      : {}),
+    ...(react ? { react: { version: '16.13.0' } } : {}),
   },
   overrides: [
     {
@@ -122,8 +155,6 @@ module.exports = {
         '@typescript-eslint/no-var-requires': 'off',
       },
     },
-    {
-      files: ['*.ts', '*.tsx'],
-    },
+    { files: ['*.ts', '*.tsx'] },
   ],
 };

--- a/packages/eslint-config-common/package.json
+++ b/packages/eslint-config-common/package.json
@@ -17,8 +17,6 @@
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "*",
     "@typescript-eslint/parser": "*",
-    "eslint-config-airbnb-base": "*",
-    "eslint-config-prettier": "*",
     "eslint-import-resolver-node": "*",
     "eslint-plugin-import": "*",
     "eslint-plugin-jsx-a11y": "*",

--- a/packages/lib-docusaurus-plugin/prism-include-languages.js
+++ b/packages/lib-docusaurus-plugin/prism-include-languages.js
@@ -1,8 +1,3 @@
-/* eslint-disable no-shadow */
-/* eslint-disable no-param-reassign */
-/* eslint-disable global-require */
-
-// eslint-disable-next-line import/no-unresolved
 import Prism from 'prism-react-renderer/prism';
 
 import extendPrism from 'lib-prism-extended';

--- a/packages/lib-react/PrismCodeBlock.tsx
+++ b/packages/lib-react/PrismCodeBlock.tsx
@@ -31,7 +31,6 @@ const PrismCodeBlock = ({
 }: Props): ReactElement => {
   return (
     <Highlight
-      // eslint-disable-next-line react/jsx-props-no-spreading
       {...defaultProps}
       theme={userDefinedTheme || flexibleTheme}
       code={children.trim()}
@@ -43,10 +42,10 @@ const PrismCodeBlock = ({
         const combinedStyle =
           userDefinedStyles == null ? style : { ...style, ...userDefinedStyles };
         const content = tokens.map((line, i) => (
-          // eslint-disable-next-line react/no-array-index-key, react/jsx-props-no-spreading, react/jsx-key
+          // eslint-disable-next-line react/no-array-index-key, react/jsx-key
           <div {...getLineProps({ line, key: i })}>
             {line.map((token, key) => (
-              // eslint-disable-next-line react/jsx-props-no-spreading, react/jsx-key
+              // eslint-disable-next-line react/jsx-key
               <span {...getTokenProps({ token, key })} />
             ))}
           </div>

--- a/packages/lib-react/package.json
+++ b/packages/lib-react/package.json
@@ -15,6 +15,7 @@
     "lib-prism-extended": "workspace:0.1.0"
   },
   "peerDependencies": {
+    "prism-react-renderer": "^1.1.1",
     "react": "^16.13.1"
   },
   "devDependencies": {

--- a/packages/monorail/src/codegen/ast/github-actions.test.ts
+++ b/packages/monorail/src/codegen/ast/github-actions.test.ts
@@ -4,6 +4,8 @@ import {
   githubActionWorkflowToString,
 } from './github-actions';
 
+const GENERATED = '@' + 'generated';
+
 it('githubActionWorkflowToString() works as expected test 1', () => {
   expect(
     githubActionWorkflowToString({
@@ -12,7 +14,7 @@ it('githubActionWorkflowToString() works as expected test 1', () => {
       workflowSecrets: ['FIREBASE_TOKEN'],
       workflowJobs: [],
     })
-  ).toBe(`# @generated
+  ).toBe(`# ${GENERATED}
 
 name: example-workflow
 on:
@@ -36,7 +38,7 @@ it('githubActionWorkflowToString() works as expected test 2', () => {
       workflowtrigger: { triggerPaths: ['foo', 'bar'], masterBranchOnly: false },
       workflowJobs: [],
     })
-  ).toBe(`# @generated
+  ).toBe(`# ${GENERATED}
 
 name: example-workflow
 on:
@@ -56,7 +58,7 @@ it('githubActionWorkflowToString() works as expected test 3', () => {
       workflowtrigger: { triggerPaths: ['foo', 'bar'], masterBranchOnly: true },
       workflowJobs: [],
     })
-  ).toBe(`# @generated
+  ).toBe(`# ${GENERATED}
 
 name: example-workflow
 on:
@@ -79,7 +81,7 @@ it('githubActionWorkflowToString() works as expected test 4', () => {
       workflowSecrets: ['FIREBASE_TOKEN'],
       workflowJobs: [],
     })
-  ).toBe(`# @generated
+  ).toBe(`# ${GENERATED}
 
 name: example-workflow
 on:
@@ -135,7 +137,7 @@ fi`
         },
       ],
     })
-  ).toBe(`# @generated
+  ).toBe(`# ${GENERATED}
 
 name: lint-generated
 on:

--- a/packages/monorail/src/index.ts
+++ b/packages/monorail/src/index.ts
@@ -2,7 +2,7 @@
 
 // Ensuring all subsequent command is run from project root, so this must be the first statement.
 try {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports,  @typescript-eslint/no-var-requires, global-require
+  // eslint-disable-next-line @typescript-eslint/no-require-imports,  @typescript-eslint/no-var-requires
   process.chdir(require('./configuration').PROJECT_ROOT_DIRECTORY);
 } catch (error) {
   // eslint-disable-next-line no-console

--- a/packages/monorail/src/validator/index.ts
+++ b/packages/monorail/src/validator/index.ts
@@ -34,7 +34,6 @@ export const assertHasFields = <S extends string>(
   if (typeof json !== 'object') {
     throw new Error(`Expect '${key}' to be an object, but got ${typeof json}!`);
   }
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-expect-error: S must be string!
   const record: Record<S, unknown> = {};
   const missingFields = requiredFields.filter((requiredKey) => {

--- a/packages/vscode-disable-generated-files-edit/index.ts
+++ b/packages/vscode-disable-generated-files-edit/index.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unresolved
 import * as vscode from 'vscode';
 
 const disabledEditDecorationType = vscode.window.createTextEditorDecorationType({
@@ -14,7 +13,6 @@ const updateGeneratedHoverForEditor = (editor: vscode.TextEditor | undefined): v
   if (editor == null) {
     return;
   }
-  // eslint-disable-next-line no-useless-concat
   if (editor.document.getText().includes('@' + 'generated')) {
     editor.setDecorations(disabledEditDecorationType, [
       {

--- a/packages/wiki/src/types.d.ts
+++ b/packages/wiki/src/types.d.ts
@@ -1,2 +1,1 @@
-// eslint-disable-next-line spaced-comment
 /// <reference types="@docusaurus/module-type-aliases" />

--- a/packages/www/pages/_app.tsx
+++ b/packages/www/pages/_app.tsx
@@ -86,10 +86,7 @@ const MaterialUIApp = (props: AppProps): ReactElement => {
           dangerouslySetInnerHTML={{ __html: themeAutoSwitcher }}
         />
       </Head>
-      <Component
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...pageProps}
-      />
+      <Component {...pageProps} />
     </>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2040,8 +2040,6 @@ __metadata:
   peerDependencies:
     "@typescript-eslint/eslint-plugin": "*"
     "@typescript-eslint/parser": "*"
-    eslint-config-airbnb-base: "*"
-    eslint-config-prettier: "*"
     eslint-import-resolver-node: "*"
     eslint-plugin-import: "*"
     eslint-plugin-jsx-a11y: "*"
@@ -5798,13 +5796,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"confusing-browser-globals@npm:^1.0.9":
-  version: 1.0.9
-  resolution: "confusing-browser-globals@npm:1.0.9"
-  checksum: 319e6d15384745d3ff4a5ca0357b687e0d36a1ab29a03084e192ea12802532de0fa7319169b09e971aba6a291f8a5ca333105e0fb239ed3f6c891f13eea2bea6
-  languageName: node
-  linkType: hard
-
 "connect-history-api-fallback@npm:^1.6.0":
   version: 1.6.0
   resolution: "connect-history-api-fallback@npm:1.6.0"
@@ -7384,33 +7375,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-airbnb-base@npm:^14.2.0":
-  version: 14.2.0
-  resolution: "eslint-config-airbnb-base@npm:14.2.0"
-  dependencies:
-    confusing-browser-globals: ^1.0.9
-    object.assign: ^4.1.0
-    object.entries: ^1.1.2
-  peerDependencies:
-    eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
-    eslint-plugin-import: ^2.21.2
-  checksum: 2d76c5e7acac1a56c9641947eaa36c0239374889e1dab6ed12890b1406178ed3417f33c01de78067d1bf064cd0b2781ac1bb2dd94ed68eb4af08b9ebc0383b2d
-  languageName: node
-  linkType: hard
-
-"eslint-config-prettier@npm:^6.11.0":
-  version: 6.11.0
-  resolution: "eslint-config-prettier@npm:6.11.0"
-  dependencies:
-    get-stdin: ^6.0.0
-  peerDependencies:
-    eslint: ">=3.14.1"
-  bin:
-    eslint-config-prettier-check: bin/cli.js
-  checksum: 59efd906c78d47753a673c205ef515fdab19cd6ea0fd992c9cb2366804861746238244526ab565ccc7448569f5472ce7646a77d0c9998787192e4ebae95df71d
-  languageName: node
-  linkType: hard
-
 "eslint-import-resolver-node@npm:^0.3.3, eslint-import-resolver-node@npm:^0.3.4":
   version: 0.3.4
   resolution: "eslint-import-resolver-node@npm:0.3.4"
@@ -8438,13 +8402,6 @@ fsevents@^1.2.7:
   version: 0.1.0
   resolution: "get-package-type@npm:0.1.0"
   checksum: a5b8beaf68d8bcdb507e23b3d2b6458e54b9061e84e2a8a94b846c8e1d794beb47fdcbda895da16ae59225bb3ea1608c0719e4f986e8a987ec2f228eaf00d78b
-  languageName: node
-  linkType: hard
-
-"get-stdin@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "get-stdin@npm:6.0.0"
-  checksum: b51d664838aef7f8353dc57371ce59cea54d8d584fec015a9d89d24561e95b97806d5b5ba120bc81574c9ed63cb3e210176ffa0ff9263c7e7ba4d56d0fe54913
   languageName: node
   linkType: hard
 
@@ -11030,6 +10987,7 @@ fsevents@^1.2.7:
     react: ^16.13.1
     typescript: 3.9.6
   peerDependencies:
+    prism-react-renderer: ^1.1.1
     react: ^16.13.1
   languageName: unknown
   linkType: soft
@@ -15369,8 +15327,6 @@ fsevents@^1.2.7:
     "@typescript-eslint/parser": ^3.8.0
     babel-jest: ^26.2.2
     eslint: ^7.6.0
-    eslint-config-airbnb-base: ^14.2.0
-    eslint-config-prettier: ^6.11.0
     eslint-import-resolver-node: ^0.3.4
     eslint-plugin-import: ^2.22.0
     eslint-plugin-jsx-a11y: ^6.3.1


### PR DESCRIPTION
airbnb config in general is not designed with TypeScript in mind. It also has a lot of slow rules. Remove it for better TS support and improve linter speed.