### PR TITLE
[wiki] Drop algolia search

### DIFF
--- a/packages/wiki/docusaurus.config.js
+++ b/packages/wiki/docusaurus.config.js
@@ -17,15 +17,7 @@ module.exports = {
   favicon: 'https://developersam.com/favicon.ico',
   themeConfig: {
     prism: { theme },
-    algolia: process.env.DEV_SAM && {
-      apiKey: process.env.ALGOLIA_PRIVATE_SEARCH_KEY,
-      indexName: 'dev-sam-intern',
-      appId: 'CYPLN8UYBW',
-    },
-    navbar: {
-      title: 'Wiki',
-      items: [],
-    },
+    navbar: { title: 'Wiki', items: [] },
   },
   presets: [
     [


### PR DESCRIPTION
When I introduce finegrained doc permission model in the future, it will become impossible to enforce permission for search statically. If I don't remove it, content might be leaked from search.