### PR TITLE
[wiki] Remove plan for binary distribution service

### DIFF
--- a/packages/wiki/docs/oss-roadmap-2020-h2.md
+++ b/packages/wiki/docs/oss-roadmap-2020-h2.md
@@ -79,15 +79,6 @@ Improve upon the current build system and achieve the following goals:
   underlying compilers;
 - Take advantage of samlang's Turing completeness to create expressive declarative build rules.
 
-### Binary Building and Distribution Service
-
-Create a service that can:
-
-- Generating GitHub Actions configurations that automatically build and test binaries for all major
-  operating systems from source and securely upload them to a remote file server;
-- A CLI for local and CI that can download the binaries from remote on demand and cache them based
-  on version hash.
-
 ### CI
 
 - CI runtime for most jobs are under 30s, while the longest running job doesn't run over 1 min;


### PR DESCRIPTION
Recent infra exploration shows that it's possible to build efficient tools in NodeJS. Check in these platform independent minimized code only takes about less than 100KB in total, which is acceptable. Therefore, there doesn't seem to be any recent need for a "binary distribution service" that's originally planned to distribute compiled binaries written in go or rust.