### PR TITLE
[wiki] Enable debug plugin in prod

### DIFF
--- a/packages/wiki/docusaurus.config.js
+++ b/packages/wiki/docusaurus.config.js
@@ -22,6 +22,7 @@ module.exports = {
       require.resolve('@docusaurus/preset-classic'),
       {
         docs: { sidebarPath: require.resolve('./sidebars.json') },
+        debug: true,
         theme: { customCss: require.resolve('./src/css/custom.css') },
       },
     ],


### PR DESCRIPTION
I don't care about the performance of this site that much since it's mainly for my internal usage. Therefore, enabling this plugin in prod to dogfood docusaurs features.