### PR TITLE
[dot-dev] Use clean URL option to map a.html to a

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -19,7 +19,8 @@
     {
       "target": "dot-dev",
       "public": "packages/dot-dev/out",
-      "ignore": ["**/.*"]
+      "ignore": ["**/.*"],
+      "cleanUrls": true
     },
     {
       "target": "samlang",

--- a/packages/dot-dev/components/FanArtWorkPage.tsx
+++ b/packages/dot-dev/components/FanArtWorkPage.tsx
@@ -1,0 +1,24 @@
+import React, { ReactElement } from 'react';
+
+import Head from 'next/head';
+
+import FanArtWorkCard from '../components/FanArtWorkCard';
+import type { FanArtWork } from '../components/data';
+
+type Props = {
+  readonly title: string;
+  readonly works: readonly FanArtWork[];
+};
+
+const ArtsPage = ({ title, works }: Props): ReactElement => (
+  <div>
+    <Head>
+      <title>{title} | Random@dev-sam</title>
+    </Head>
+    {works.map((work) => (
+      <FanArtWorkCard key={work.pageLink} {...work} />
+    ))}
+  </div>
+);
+
+export default ArtsPage;

--- a/packages/dot-dev/pages/fan-art-iteration-0.tsx
+++ b/packages/dot-dev/pages/fan-art-iteration-0.tsx
@@ -1,17 +1,10 @@
 import React, { ReactElement } from 'react';
 
-import Head from 'next/head';
-
-import FanArtWorkCard from '../components/FanArtWorkCard';
+import FanArtWorkPage from '../components/FanArtWorkPage';
 import { FAN_ART_ITERATION_0 } from '../components/data';
 
-const FanArtItemPage = (): ReactElement => (
-  <div>
-    <Head>
-      <title>Fan Arts Iteration 0 | Random@dev-sam</title>
-    </Head>
-    <FanArtWorkCard {...FAN_ART_ITERATION_0} />
-  </div>
+const ArtsPage = (): ReactElement => (
+  <FanArtWorkPage title="Fan Art Iteration 0" works={[FAN_ART_ITERATION_0]} />
 );
 
-export default FanArtItemPage;
+export default ArtsPage;

--- a/packages/dot-dev/pages/fan-art-iteration-1.tsx
+++ b/packages/dot-dev/pages/fan-art-iteration-1.tsx
@@ -1,17 +1,10 @@
 import React, { ReactElement } from 'react';
 
-import Head from 'next/head';
-
-import FanArtWorkCard from '../components/FanArtWorkCard';
+import FanArtWorkPage from '../components/FanArtWorkPage';
 import { FAN_ART_ITERATION_1 } from '../components/data';
 
-const FanArtItemPage = (): ReactElement => (
-  <div>
-    <Head>
-      <title>Fan Arts Iteration 1 | Random@dev-sam</title>
-    </Head>
-    <FanArtWorkCard {...FAN_ART_ITERATION_1} />
-  </div>
+const ArtsPage = (): ReactElement => (
+  <FanArtWorkPage title="Fan Art Iteration 1" works={[FAN_ART_ITERATION_1]} />
 );
 
-export default FanArtItemPage;
+export default ArtsPage;

--- a/packages/dot-dev/pages/fan-art-iteration-2.tsx
+++ b/packages/dot-dev/pages/fan-art-iteration-2.tsx
@@ -1,17 +1,10 @@
 import React, { ReactElement } from 'react';
 
-import Head from 'next/head';
-
-import FanArtWorkCard from '../components/FanArtWorkCard';
+import FanArtWorkPage from '../components/FanArtWorkPage';
 import { FAN_ART_ITERATION_2 } from '../components/data';
 
-const FanArtItemPage = (): ReactElement => (
-  <div>
-    <Head>
-      <title>Fan Arts Iteration 2 | Random@dev-sam</title>
-    </Head>
-    <FanArtWorkCard {...FAN_ART_ITERATION_2} />
-  </div>
+const ArtsPage = (): ReactElement => (
+  <FanArtWorkPage title="Fan Art Iteration 2" works={[FAN_ART_ITERATION_2]} />
 );
 
-export default FanArtItemPage;
+export default ArtsPage;

--- a/packages/dot-dev/pages/index.tsx
+++ b/packages/dot-dev/pages/index.tsx
@@ -1,19 +1,13 @@
 import React, { ReactElement } from 'react';
 
-import Head from 'next/head';
-
-import FanArtWorkCard from '../components/FanArtWorkCard';
+import FanArtWorkPage from '../components/FanArtWorkPage';
 import { FAN_ART_ITERATION_0, FAN_ART_ITERATION_1, FAN_ART_ITERATION_2 } from '../components/data';
 
 const ArtsPage = (): ReactElement => (
-  <div>
-    <Head>
-      <title>Fan Arts | Random@dev-sam</title>
-    </Head>
-    <FanArtWorkCard {...FAN_ART_ITERATION_0} />
-    <FanArtWorkCard {...FAN_ART_ITERATION_1} />
-    <FanArtWorkCard {...FAN_ART_ITERATION_2} />
-  </div>
+  <FanArtWorkPage
+    title="Fan Arts"
+    works={[FAN_ART_ITERATION_0, FAN_ART_ITERATION_1, FAN_ART_ITERATION_2]}
+  />
 );
 
 export default ArtsPage;


### PR DESCRIPTION
Also make some changes to factor out common page code. Mostly to trigger a re-deploy in CI.

Thanks @meganyin13 for bug report.