### PR TITLE
[lib-react] Unbreak code editor by removing trim

### DIFF
--- a/packages/lib-react/PrismCodeBlock.tsx
+++ b/packages/lib-react/PrismCodeBlock.tsx
@@ -33,7 +33,7 @@ const PrismCodeBlock = ({
     <Highlight
       {...defaultProps}
       theme={userDefinedTheme || flexibleTheme}
-      code={children.trim()}
+      code={children}
       language={language as Language}
     >
       {({ className, style, tokens, getLineProps, getTokenProps }) => {

--- a/packages/lib-react/PrismCodeEditor.tsx
+++ b/packages/lib-react/PrismCodeEditor.tsx
@@ -246,7 +246,7 @@ const PrismCodeEditor = ({
         theme={theme}
         style={{ height: codeBlockHeight + 16 }}
       >
-        {code.trim()}
+        {code}
       </CodeBlock>
     </div>
   );

--- a/packages/www/src/components/StickyCodeBlock.tsx
+++ b/packages/www/src/components/StickyCodeBlock.tsx
@@ -4,8 +4,7 @@ import styles from './StickyCodeBlock.module.css';
 
 import CodeBlock, { flexibleTheme } from 'lib-react/PrismCodeBlock';
 
-const code = `
-/**
+const code = `/**
  * Copyright (C) 2015–2020 Developer Sam.
  *
  * @author sam
@@ -34,8 +33,7 @@ class Developer(
 }
 class Main {
   function main(): Developer = Developer.sam()
-}
-`;
+}`;
 
 const patchedTheme = {
   ...flexibleTheme,


### PR DESCRIPTION
Trimming the code but not the textarea results in some really weird errors.