### PR TITLE
[github-contribution-alert] Count private repo contributions

### DIFF
--- a/packages/github-contribution-alert/index.ts
+++ b/packages/github-contribution-alert/index.ts
@@ -17,6 +17,7 @@ const graphQLClient = new GraphQLClient('https://api.github.com/graphql', {
 
 type TotalCount = { readonly totalCount: number };
 type ContributionsCollection = {
+  readonly restrictedContributionsCount: number;
   readonly issueContributions: TotalCount;
   readonly pullRequestContributions: TotalCount;
   readonly pullRequestReviewContributions: {
@@ -49,6 +50,7 @@ const fetchContributionsCollection = async (
     `query {
   user(login: "${githubUser}") {
     contributionsCollection(from: "${todayInNYStart.toISO()}", to: "${todayInNYEnd.toISO()}") {
+      restrictedContributionsCount
       issueContributions {
         totalCount
       }
@@ -89,12 +91,14 @@ const fetchContributionsCollection = async (
 };
 
 const sumContributions = ({
+  restrictedContributionsCount,
   issueContributions,
   pullRequestContributions,
   pullRequestReviewContributions,
   repositoryContributions,
   commitContributionsByRepository,
 }: ContributionsCollection): number =>
+  restrictedContributionsCount +
   issueContributions.totalCount +
   pullRequestContributions.totalCount +
   pullRequestReviewContributions.nodes.reduce(


### PR DESCRIPTION
## Summary

Also count private-repo contributions so that there are fewer false positives.

## Test Plan

Given this test on using github's graphql API explorer, I believe it is correct:

<img width="1061" alt="Screen Shot 2020-11-17 at 19 36 06" src="https://user-images.githubusercontent.com/4290500/99467413-65406f00-290c-11eb-859d-dc8093772a17.png">

There is no way to dig deeper into the type of contribution beyond that number, so I have to assume they are safe.