### PR TITLE
[ten] Allow online game to start with empty board

### DIFF
--- a/packages/ten/src/components/online-multiplayer-firestore.ts
+++ b/packages/ten/src/components/online-multiplayer-firestore.ts
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 
 import firebase from 'firebase/app';
 
-import { Board, emptyBoard, makeMoveWithoutCheck } from '../game/board';
+import { Board, emptyBoard } from '../game/board';
 
 import { getAppUser } from 'lib-firebase/authentication';
 
@@ -49,7 +49,7 @@ export const startFirestoreOnlineTENGame = (
   const gameData = {
     blackPlayerEmail,
     whitePlayerEmail,
-    board: makeMoveWithoutCheck(emptyBoard, [4, 4]),
+    board: emptyBoard,
   };
   const document = gameDataCollection.doc();
   document.set(gameData);


### PR DESCRIPTION
Allow black to make the non-optimal move. 🧐

While making this change, I also fixed the security rule to make `allow get: if true`. This can fix the initial race condition when fetching the data.

Thanks @meganyin13 for testing in prod with me to find this issue. 🥰 