### PR TITLE
[dependency] Bump dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-import-resolver-node": "^0.3.4",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsx-a11y": "^6.4.1",
-    "eslint-plugin-react": "^7.21.5",
+    "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "husky": "^4.3.6",
     "jest": "^26.6.3",

--- a/packages/codegen-cli/package.json
+++ b/packages/codegen-cli/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@dev-sam/bundler": "workspace:^0.0.2",
     "@types/jest": "^26.0.19",
-    "@types/node": "^14.14.16",
+    "@types/node": "^14.14.17",
     "@vercel/ncc": "^0.24.0",
     "lib-changed-files": "workspace:^0.0.1",
     "lib-find-monorepo-root": "workspace:^0.0.1",

--- a/packages/dot-dev/package.json
+++ b/packages/dot-dev/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.19",
-    "@types/node": "^14.14.16",
+    "@types/node": "^14.14.17",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "typescript": "^4.1.3"

--- a/packages/eslint-config-common/package.json
+++ b/packages/eslint-config-common/package.json
@@ -39,6 +39,6 @@
     }
   },
   "devDependencies": {
-    "@types/node": "^14.14.16"
+    "@types/node": "^14.14.17"
   }
 }

--- a/packages/github-contribution-alert/package.json
+++ b/packages/github-contribution-alert/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@types/luxon": "^1.25.0",
-    "@types/node": "^14.14.16",
+    "@types/node": "^14.14.17",
     "@vercel/ncc": "^0.24.1",
     "typescript": "^4.1.3"
   }

--- a/packages/lib-changed-files/package.json
+++ b/packages/lib-changed-files/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.19",
-    "@types/node": "^14.14.16",
+    "@types/node": "^14.14.17",
     "lib-common": "0.0.1",
     "typescript": "^4.1.3"
   }

--- a/packages/lib-codegen/package.json
+++ b/packages/lib-codegen/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.19",
-    "@types/node": "^14.14.16",
+    "@types/node": "^14.14.17",
     "typescript": "^4.1.3"
   }
 }

--- a/packages/lib-docusaurus-plugin/package.json
+++ b/packages/lib-docusaurus-plugin/package.json
@@ -17,6 +17,7 @@
     "lib-react": "workspace:0.1.0"
   },
   "devDependencies": {
+    "@types/node": "^14.14.17",
     "typescript": "^4.1.3"
   },
   "peerDependencies": {

--- a/packages/lib-find-monorepo-root/package.json
+++ b/packages/lib-find-monorepo-root/package.json
@@ -6,7 +6,7 @@
     "compile": "tsc --noEmit"
   },
   "devDependencies": {
-    "@types/node": "^14.14.16",
+    "@types/node": "^14.14.17",
     "typescript": "^4.1.3"
   }
 }

--- a/packages/lib-firebase/package.json
+++ b/packages/lib-firebase/package.json
@@ -14,7 +14,7 @@
     "react": "^17.0.1"
   },
   "devDependencies": {
-    "@types/node": "^14.14.16",
+    "@types/node": "^14.14.17",
     "@types/react": "^17.0.0",
     "firebase": "^8.1.1",
     "typescript": "^4.1.3"

--- a/packages/lib-incremental/package.json
+++ b/packages/lib-incremental/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.19",
-    "@types/node": "^14.14.16",
+    "@types/node": "^14.14.17",
     "typescript": "^4.1.3"
   }
 }

--- a/packages/monorail/package.json
+++ b/packages/monorail/package.json
@@ -17,7 +17,7 @@
     "@dev-sam/bundler": "workspace:^0.0.2",
     "@dev-sam/yarn-workspaces-json-types": "0.0.1",
     "@types/jest": "^26.0.19",
-    "@types/node": "^14.14.16",
+    "@types/node": "^14.14.17",
     "typescript": "^4.1.3"
   }
 }

--- a/packages/repo-codegen-services/package.json
+++ b/packages/repo-codegen-services/package.json
@@ -16,7 +16,7 @@
     "@dev-sam/bundler": "workspace:^0.0.2",
     "@dev-sam/yarn-workspaces-json-types": "0.0.1",
     "@types/jest": "^26.0.19",
-    "@types/node": "^14.14.16",
+    "@types/node": "^14.14.17",
     "@vercel/ncc": "^0.24.0",
     "typescript": "^4.1.3"
   }

--- a/packages/sam-bundler/package.json
+++ b/packages/sam-bundler/package.json
@@ -12,6 +12,6 @@
     "@vercel/ncc": "^0.26.0"
   },
   "devDependencies": {
-    "@types/node": "^14.14.16"
+    "@types/node": "^14.14.17"
   }
 }

--- a/packages/sam-watcher-server/package.json
+++ b/packages/sam-watcher-server/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.7",
-    "@types/node": "^14.14.16",
+    "@types/node": "^14.14.17",
     "@vercel/ncc": "^0.24.0",
     "typescript": "^4.1.3"
   }

--- a/packages/ten/package.json
+++ b/packages/ten/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.0.0-alpha.70",
-    "@types/node": "^14.14.16",
+    "@types/node": "^14.14.17",
     "@types/react": "^17.0.0",
     "typescript": "^4.1.3"
   }

--- a/packages/wiki/package.json
+++ b/packages/wiki/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "2.0.0-alpha.70",
-    "@types/node": "^14.14.16",
+    "@types/node": "^14.14.17",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@types/remarkable": "1.7.4",

--- a/packages/www/package.json
+++ b/packages/www/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.19",
-    "@types/node": "^14.14.16",
+    "@types/node": "^14.14.17",
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "next-transpile-modules": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1750,7 +1750,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@dev-sam/bundler@workspace:packages/sam-bundler"
   dependencies:
-    "@types/node": ^14.14.16
+    "@types/node": ^14.14.17
     "@vercel/ncc": ^0.26.0
   bin:
     sam-bundle: ./index.js
@@ -1763,7 +1763,7 @@ __metadata:
   dependencies:
     "@dev-sam/bundler": "workspace:^0.0.2"
     "@types/jest": ^26.0.19
-    "@types/node": ^14.14.16
+    "@types/node": ^14.14.17
     "@vercel/ncc": ^0.24.0
     lib-changed-files: "workspace:^0.0.1"
     lib-find-monorepo-root: "workspace:^0.0.1"
@@ -1778,7 +1778,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@dev-sam/eslint-config-common@workspace:packages/eslint-config-common"
   dependencies:
-    "@types/node": ^14.14.16
+    "@types/node": ^14.14.17
   peerDependencies:
     "@typescript-eslint/eslint-plugin": "*"
     "@typescript-eslint/parser": "*"
@@ -1804,7 +1804,7 @@ __metadata:
     "@dev-sam/bundler": "workspace:^0.0.2"
     "@dev-sam/yarn-workspaces-json-types": 0.0.1
     "@types/jest": ^26.0.19
-    "@types/node": ^14.14.16
+    "@types/node": ^14.14.17
     lib-changed-files: "workspace:^0.0.1"
     lib-find-monorepo-root: "workspace:^0.0.1"
     lib-incremental: "workspace:^0.0.1"
@@ -1826,7 +1826,7 @@ __metadata:
   resolution: "@dev-sam/watcher-server@workspace:packages/sam-watcher-server"
   dependencies:
     "@types/express": ^4.17.7
-    "@types/node": ^14.14.16
+    "@types/node": ^14.14.17
     "@vercel/ncc": ^0.24.0
     chokidar: ^3.4.2
     express: ^4.17.1
@@ -3745,10 +3745,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^14.14.16":
-  version: 14.14.16
-  resolution: "@types/node@npm:14.14.16"
-  checksum: 220a7496ec73861ad7fb4ae762618bb46ac9d5d5f92f3a2fcebfd1a81a509ff558eface7bcd1d632598a8a28f856a74b324e7165918e8334a59c221cb06d15e3
+"@types/node@npm:^14.14.17":
+  version: 14.14.17
+  resolution: "@types/node@npm:14.14.17"
+  checksum: 2bb32c683d8446128cf3240b4af6cc884c6ee006a845d1901becadc46255d1263bf265abde5ccb37a09d9a318fc3964d07afc941d52544f2d7f249dbb28d9420
   languageName: node
   linkType: hard
 
@@ -7700,7 +7700,7 @@ __metadata:
   resolution: "dot-dev@workspace:packages/dot-dev"
   dependencies:
     "@types/jest": ^26.0.19
-    "@types/node": ^14.14.16
+    "@types/node": ^14.14.17
     "@types/react": ^17.0.0
     "@types/react-dom": ^17.0.0
     infima: 0.2.0-alpha.18
@@ -8179,9 +8179,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react@npm:^7.21.5":
-  version: 7.21.5
-  resolution: "eslint-plugin-react@npm:7.21.5"
+"eslint-plugin-react@npm:^7.22.0":
+  version: 7.22.0
+  resolution: "eslint-plugin-react@npm:7.22.0"
   dependencies:
     array-includes: ^3.1.1
     array.prototype.flatmap: ^1.2.3
@@ -8196,7 +8196,7 @@ __metadata:
     string.prototype.matchall: ^4.0.2
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7
-  checksum: a7123f6feb287ad7e15d36b1c9fda8f78a0f0d39b9ee2d6479a5f0ad0effb8f60f639ef7449cecabb711095060e487f0950b69478b22768547b909c0de4f3afd
+  checksum: 34927cb4880984e3a3e413ef57ebedbc4c4bf8e26f3cf561986e240c621d0873765fc5eef2be22171625deab2f77d0ec7013b422987ae5296fbdee0c682c6cc5
   languageName: node
   linkType: hard
 
@@ -9366,7 +9366,7 @@ fsevents@^1.2.7:
   dependencies:
     "@sendgrid/mail": ^7.2.6
     "@types/luxon": ^1.25.0
-    "@types/node": ^14.14.16
+    "@types/node": ^14.14.17
     "@vercel/ncc": ^0.24.1
     dotenv: ^8.2.0
     firebase-admin: ^9.2.0
@@ -12105,7 +12105,7 @@ fsevents@^1.2.7:
   resolution: "lib-changed-files@workspace:packages/lib-changed-files"
   dependencies:
     "@types/jest": ^26.0.19
-    "@types/node": ^14.14.16
+    "@types/node": ^14.14.17
     lib-common: 0.0.1
     typescript: ^4.1.3
   languageName: unknown
@@ -12116,7 +12116,7 @@ fsevents@^1.2.7:
   resolution: "lib-codegen@workspace:packages/lib-codegen"
   dependencies:
     "@types/jest": ^26.0.19
-    "@types/node": ^14.14.16
+    "@types/node": ^14.14.17
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
@@ -12134,6 +12134,7 @@ fsevents@^1.2.7:
   resolution: "lib-docusaurus-plugin@workspace:packages/lib-docusaurus-plugin"
   dependencies:
     "@docusaurus/types": 2.0.0-alpha.70
+    "@types/node": ^14.14.17
     lib-prism-extended: "workspace:0.1.0"
     lib-react: "workspace:0.1.0"
     typescript: ^4.1.3
@@ -12149,7 +12150,7 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "lib-find-monorepo-root@workspace:packages/lib-find-monorepo-root"
   dependencies:
-    "@types/node": ^14.14.16
+    "@types/node": ^14.14.17
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
@@ -12158,7 +12159,7 @@ fsevents@^1.2.7:
   version: 0.0.0-use.local
   resolution: "lib-firebase@workspace:packages/lib-firebase"
   dependencies:
-    "@types/node": ^14.14.16
+    "@types/node": ^14.14.17
     "@types/react": ^17.0.0
     firebase: ^8.1.1
     lib-react: 0.1.0
@@ -12185,7 +12186,7 @@ fsevents@^1.2.7:
   resolution: "lib-incremental@workspace:packages/lib-incremental"
   dependencies:
     "@types/jest": ^26.0.19
-    "@types/node": ^14.14.16
+    "@types/node": ^14.14.17
     typescript: ^4.1.3
   languageName: unknown
   linkType: soft
@@ -16557,7 +16558,7 @@ fsevents@^1.2.7:
     "@dev-sam/bundler": "workspace:^0.0.2"
     "@dev-sam/yarn-workspaces-json-types": 0.0.1
     "@types/jest": ^26.0.19
-    "@types/node": ^14.14.16
+    "@types/node": ^14.14.17
     "@vercel/ncc": ^0.24.0
     lib-codegen: "workspace:0.0.1"
     lib-common: "workspace:0.0.1"
@@ -16863,7 +16864,7 @@ fsevents@^1.2.7:
     eslint-import-resolver-node: ^0.3.4
     eslint-plugin-import: ^2.22.1
     eslint-plugin-jsx-a11y: ^6.4.1
-    eslint-plugin-react: ^7.21.5
+    eslint-plugin-react: ^7.22.0
     eslint-plugin-react-hooks: ^4.2.0
     husky: ^4.3.6
     jest: ^26.6.3
@@ -18333,7 +18334,7 @@ fsevents@^1.2.7:
     "@docusaurus/core": 2.0.0-alpha.70
     "@docusaurus/module-type-aliases": 2.0.0-alpha.70
     "@docusaurus/plugin-content-pages": 2.0.0-alpha.70
-    "@types/node": ^14.14.16
+    "@types/node": ^14.14.17
     "@types/react": ^17.0.0
     firebase: ^8.1.1
     infima: 0.2.0-alpha.18
@@ -19850,7 +19851,7 @@ typescript@^4.1.3:
     "@docusaurus/preset-classic": 2.0.0-alpha.70
     "@docusaurus/theme-classic": 2.0.0-alpha.70
     "@mdx-js/react": ^1.6.4
-    "@types/node": ^14.14.16
+    "@types/node": ^14.14.17
     "@types/react": ^17.0.0
     "@types/react-dom": ^17.0.0
     "@types/remarkable": 1.7.4
@@ -19964,7 +19965,7 @@ typescript@^4.1.3:
   resolution: "www@workspace:packages/www"
   dependencies:
     "@types/jest": ^26.0.19
-    "@types/node": ^14.14.16
+    "@types/node": ^14.14.17
     "@types/react": ^17.0.0
     "@types/react-dom": ^17.0.0
     clsx: ^1.1.1


### PR DESCRIPTION
The real reason is to trigger a rebuild across all my websites, to bump the copyright date to 2021.