### PR TITLE
[samlang] Remove line height override

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
- 

--- a/packages/samlang/src/css/custom.css
+++ b/packages/samlang/src/css/custom.css
@@ -36,7 +36,3 @@ pre {
 .token-line {
   line-height: 1.35;
 }
-
-.prism-code {
-  font-size: 14px;
-}


### PR DESCRIPTION
Looks like it's initially added to help the editor, but the editor doesn't really need it. It also makes the font elsewhere unnecessarily small. Therefore, let's remove it once and for all.