### PR TITLE
[threads-helper] Fix after update

### DIFF
--- a/packages/threads-extension/background.js
+++ b/packages/threads-extension/background.js
@@ -3,10 +3,10 @@
 let changed = false;
 window.setInterval(() => {
   if (changed) return;
-  const node = Array.from(document.querySelectorAll("span")).find(
+  const nodes = Array.from(document.querySelectorAll("span")).filter(
     (el) => el.textContent === "For you",
   );
-  if (node) {
+  for (const node of nodes) {
     console.log("[threads-helper] Force following feed");
     node.click();
     changed = true;

--- a/packages/threads-extension/manifest.json
+++ b/packages/threads-extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Threads Helper",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "manifest_version": 3,
   "description": "Force defaulting to following feed",
   "permissions": [],


### PR DESCRIPTION
For some reasons, it starts to have two `span` with text "For you".

Fix by clicking both of them. If in the future there are three, just click them all.