### PR TITLE
[threads-helper] Use v2 manifest

### DIFF
--- a/packages/threads-extension/manifest.json
+++ b/packages/threads-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Threads Helper",
   "version": "0.0.2",
-  "manifest_version": 3,
+  "manifest_version": 2,
   "description": "Force defaulting to following feed",
   "permissions": [],
   "icons": {


### PR DESCRIPTION
I want to publish it to firefox as well, but it's not happy with v3.